### PR TITLE
fix: correct dataset path

### DIFF
--- a/configs/skin_det.yaml
+++ b/configs/skin_det.yaml
@@ -1,5 +1,8 @@
 
-path: data/skin_det
+# Dataset root path. Using a relative path to this file caused training to look for
+# data/skin_det inside the configs directory, which does not exist. Point one
+# directory up to reference the actual dataset location at data/skin_det.
+path: ../data/skin_det
 train: images/train
 val: images/val
 names:


### PR DESCRIPTION
## Summary
- fix dataset config path to correctly point to data/skin_det

## Testing
- `python - <<'PY'
from pathlib import Path
import re
text=Path('configs/skin_det.yaml').read_text().splitlines()
path_line=[l for l in text if l.startswith('path:')][0]
path_value=path_line.split(':',1)[1].strip()
resolved=(Path('configs')/path_value).resolve()
print('Path in YAML resolves to', resolved)
print('Exists?', resolved.exists())
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab7129c0d48330bfbe944776e3670e